### PR TITLE
fix(ticketTable): reset pagination to page 1 on filter change

### DIFF
--- a/frontend/src/components/tables/ticketTable/hooks.js
+++ b/frontend/src/components/tables/ticketTable/hooks.js
@@ -59,6 +59,8 @@ const useTicketTableHooks = (tableMode) => {
 
   // on mount and when checkedThingIds or selectedThingId changes, refetch data
   useEffect(() => {
+    // Reset to page 1 when filters change
+    navigation.setQueryParam.pageNumber(1);
     doRefetch();
   }, [
     navigation.getQueryParam.thingIds,
@@ -67,9 +69,16 @@ const useTicketTableHooks = (tableMode) => {
     navigation.getQueryParam.userId,
     navigation.getQueryParam.search,
     navigation.getQueryParam.ticketCategoryIds,
-    pageNumber,
+    // Note: We don't include pageNumber in the dependency array
+    // to prevent an infinite loop
+    // pageNumber,
     pageSize,
   ]);
+
+  // Handle page number changes separately
+  useEffect(()=>{
+    doRefetch();
+  },[pageNumber,pageSize]);
 
   // helper to get row class names in the table
   const getRowClassName = (record) => {


### PR DESCRIPTION
I've addressed the pagination issue in #27. Here's what I changed:

Changes Made:
- Reset pagination to page 1 when any filter is applied
- Separated filter and pagination logic for better maintainability
- Added proper dependency arrays to prevent unnecessary re-renders

Testing Steps:
1. Navigate to page 2+ of the tickets
2. Apply a filter
3. Verify the table resets to page 1 with filtered results

Let me know if you'd like any adjustments!